### PR TITLE
Fix fieldmapping key case

### DIFF
--- a/src/Bank/BankFactory.php
+++ b/src/Bank/BankFactory.php
@@ -24,7 +24,7 @@ class BankFactory
             'name' => 'setName',
             'location' => 'setLocation',
             "organisation" => 'setOrganization',
-            'pinTanUrl' => 'setPinTanUrl',
+            'pinTanURL' => 'setPinTanUrl',
             'protocol' => 'setFintsVersion',
             "hbciDomain" => 'setHbciUrl',
             "hbciAddress" => 'setHbciIp',


### PR DESCRIPTION
Incorrect key case in the BankFactory fieldmapping prevents correct creation of bank objects.
PinTanUrl is always null.